### PR TITLE
Reintroduce the autoreloader executable

### DIFF
--- a/autoreloader/main.go
+++ b/autoreloader/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/agschwender/autoreload"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("Must supply a command to autoreload")
+	}
+
+	// Verify that the supplied command exists and generate an exec
+	// command.
+	path, err := exec.LookPath(os.Args[1])
+	if err != nil {
+		log.Fatalf("Cannot find executable: %s", os.Args[1])
+	}
+
+	cmd := exec.Command(path, os.Args[2:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	var wg sync.WaitGroup
+
+	// Start the autoreloader monitor.
+	autoreload.New(
+		autoreload.WithCommand(os.Args[1]),
+		autoreload.WithOnReload(func() {
+			// When the application needs to reload, we must kill the
+			// spawned command.
+
+			log.Printf("Killing process")
+			if err := cmd.Process.Kill(); err != nil {
+				log.Fatalf("Failed to kill process: %v", err)
+			}
+
+			// Add to the wait group so that the autoreloader executable
+			// will not exit due to the command being killed.
+			wg.Add(1)
+		}),
+	).Start()
+
+	// Run the supplied command
+	err = cmd.Run()
+
+	// If there is anything in the wait group, it means that the
+	// autoreloader package is restarting the executable. Wait here
+	// until it has completed that process.
+	wg.Wait()
+
+	// Maintain the error exit code of the supplied command.
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			os.Exit(int(exiterr.ExitCode()))
+		} else {
+			os.Exit(1)
+		}
+	}
+}

--- a/example/main.go
+++ b/example/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"net/http"
 	"os"
@@ -14,14 +15,25 @@ import (
 func main() {
 	log.Printf("Starting application")
 
+	// In a real production environment, you will likely want the
+	// autoreload flag or environment variables to be defaulted to false
+	// so that it is only enabled in the local environment.
+	var shouldAutoReload bool
+	flag.BoolVar(&shouldAutoReload, "autoreload", true, "enable autoreload")
+	flag.Parse()
+
 	server := &http.Server{Addr: ":8000"}
 
-	autoreload.New(
-		autoreload.WithMaxAttempts(6),
-		autoreload.WithOnReload(func() {
-			server.Shutdown(context.Background())
-		}),
-	).Start()
+	if shouldAutoReload {
+		log.Printf("Auto-reload is enabled")
+		autoreload.New(
+			autoreload.WithMaxAttempts(6),
+			autoreload.WithOnReload(func() {
+				log.Printf("Received change event, shutting down")
+				server.Shutdown(context.Background())
+			}),
+		).Start()
+	}
 
 	go func() {
 		log.Printf("Starting HTTP server")


### PR DESCRIPTION
## Issue

The `autoreloader` command was not able to detect changes to the supplied command and as a result failed to function as expected.

## Change

This change resolves issues with the `autoreloader` command due to the `fsnotify` events not firing when executing the command via `syscall.Exec`. The call was replaced with `exec.Command` and should allow the executable to function as expected.